### PR TITLE
The values for the UIColor of the Effect have to be floats, otherwise…

### DIFF
--- a/ExpensesApp.iOS/Effects/SelectedEffect.cs
+++ b/ExpensesApp.iOS/Effects/SelectedEffect.cs
@@ -15,7 +15,7 @@ namespace ExpensesApp.iOS.Effects
 
         protected override void OnAttached()
         {
-            selectedColor = new UIColor(176 / 255, 152 / 255, 164 / 255, 255 / 255);
+            selectedColor = new UIColor(176.0f / 255, 152.0f / 255, 164.0f / 255, 255.0f / 255);
         }
 
         protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)


### PR DESCRIPTION
… the color will be black. This commit solves that. Simply changed the UIColor constructor called to receive the values as floats instead of ints. Now the background color won't be black, it will be the actual pinkish color.